### PR TITLE
Add a Dockerfile to add custom certs to the delegate image

### DIFF
--- a/Dockerfile.custom-certs
+++ b/Dockerfile.custom-certs
@@ -1,0 +1,8 @@
+FROM harness/delegate:23.11.81408
+
+USER 0
+ADD custom-ca.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+RUN keytool -noprompt -import -trustcacerts -file /etc/pki/ca-trust/source/anchors/custom-ca.pem -alias custom-ca -keystore /opt/java/openjdk/lib/security/cacerts -storepass changeit
+ENV DESTINATION_CA_PATH="/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
+USER 1001

--- a/Dockerfile.custom-certs
+++ b/Dockerfile.custom-certs
@@ -4,5 +4,6 @@ USER 0
 ADD custom-ca.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 RUN keytool -noprompt -import -trustcacerts -file /etc/pki/ca-trust/source/anchors/custom-ca.pem -alias custom-ca -keystore /opt/java/openjdk/lib/security/cacerts -storepass changeit
+RUN mkdir -p /kaniko/ssl/certs/; cp /etc/ssl/certs/ca-bundle.crt /kaniko/ssl/certs/additional-ca-cert-bundle.crt
 ENV DESTINATION_CA_PATH="/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
 USER 1001


### PR DESCRIPTION
This adds an example Dockerfile to add custom CA certs to the delegate, both so it can connect to SMP and also populates the environment variable used to provide those certs to CI and STO stages.