### PR TITLE
Incorporate new built in import_certificates.sh script

### DIFF
--- a/Dockerfile.custom-certs
+++ b/Dockerfile.custom-certs
@@ -1,9 +1,7 @@
 FROM harness/delegate:23.11.81408
 
 USER 0
-ADD custom-ca.pem /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust
-RUN keytool -noprompt -import -trustcacerts -file /etc/pki/ca-trust/source/anchors/custom-ca.pem -alias custom-ca -keystore /opt/java/openjdk/lib/security/cacerts -storepass changeit
-RUN mkdir -p /kaniko/ssl/certs/; cp /etc/ssl/certs/ca-bundle.crt /kaniko/ssl/certs/additional-ca-cert-bundle.crt
+ADD custom-ca.pem /opt/harness-delegate/ca-bundle/custom-ca.pem
+RUN /opt/harness-delegate/load_certificates.sh
 ENV DESTINATION_CA_PATH="/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
 USER 1001

--- a/Dockerfile.custom-certs
+++ b/Dockerfile.custom-certs
@@ -1,0 +1,8 @@
+FROM harness/delegate:23.11.81408
+
+USER 0
+ADD custom-ca.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+RUN keytool -noprompt -import -trustcacerts -file /etc/pki/ca-trust/source/anchors/custom-ca.pem -alias custom-ca -keystore /opt/java/openjdk/lib/security/cacerts -storepass changeit
+ENV DESTINATION_CA_PATH="/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
+USER 1001

--- a/Dockerfile.custom-certs
+++ b/Dockerfile.custom-certs
@@ -2,6 +2,7 @@ FROM harness/delegate:23.11.81408
 
 USER 0
 ADD custom-ca.pem /opt/harness-delegate/ca-bundle/custom-ca.pem
-RUN /opt/harness-delegate/load_certificates.sh
-ENV DESTINATION_CA_PATH="/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
+RUN /opt/harness-delegate/load_certificates.sh && rm /opt/harness-delegate/ca-bundle/custom-ca.pem
+ENV ADDITIONAL_CERTS_PATH="/etc/ssl/certs/ca-bundle.crt"
+ENV CI_MOUNT_VOLUMES="/etc/ssl/certs/ca-bundle.crt:/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
 USER 1001

--- a/Dockerfile.custom-certs
+++ b/Dockerfile.custom-certs
@@ -4,5 +4,6 @@ USER 0
 ADD custom-ca.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 RUN keytool -noprompt -import -trustcacerts -file /etc/pki/ca-trust/source/anchors/custom-ca.pem -alias custom-ca -keystore /opt/java/openjdk/lib/security/cacerts -storepass changeit
+RUN mkdir -p /kaniko/ssl/certs/; cp /etc/ssl/certs/ca-bundle.crt /kaniko/ssl/certs/additional-ca-cert-bundle.crt
 ENV DESTINATION_CA_PATH="/etc/ssl/certs/ca-bundle.crt,/kaniko/ssl/certs/additional-ca-cert-bundle.crt"
 USER 1001


### PR DESCRIPTION
This PR updates the custom certs example Dockerfile to incorporate a new built in script that will load the certs in all the right places.  It also updates the CI environment variables to work with this new style when running as non-root.